### PR TITLE
Add unit tests and remove unused certificate helpers

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,79 @@
+package config
+
+import "testing"
+
+// setMandatory sets the three variables config.Get treats as required, so a
+// test can exercise the defaulting paths without tripping its Fatal calls.
+func setMandatory(t *testing.T) {
+	t.Helper()
+	t.Setenv("DATABASE_USER", "user")
+	t.Setenv("DATABASE_PASSWORD", "password")
+	t.Setenv("DATABASE_NAME", "ctlogs")
+}
+
+func TestGetAppliesDefaultsWhenOptionalVarsAreUnset(t *testing.T) {
+	setMandatory(t)
+	t.Setenv("SERVER_PORT", "")
+	t.Setenv("DATABASE_HOST", "")
+	t.Setenv("DATABASE_PORT", "")
+	t.Setenv("DATABASE_SCHEMA", "")
+	t.Setenv("DATABASE_SSL_MODE", "")
+	t.Setenv("SSLMATE_BASE_URL", "")
+
+	got := Get()
+
+	for _, tc := range []struct{ name, got, want string }{
+		{"server port", got.Server.Port, "8080"},
+		{"database host", got.Database.Host, "localhost"},
+		{"database port", got.Database.Port, "5432"},
+		{"database schema", got.Database.Schema, "ctlogs"},
+		{"database ssl mode", got.Database.SslMode, "require"},
+		{"sslmate base url", got.SslMate.BaseUrl, "https://api.certspotter.com"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestGetPrefersEnvironmentOverDefaults(t *testing.T) {
+	setMandatory(t)
+	t.Setenv("SERVER_PORT", "9090")
+	t.Setenv("DATABASE_HOST", "db.internal")
+	t.Setenv("DATABASE_PORT", "6543")
+	t.Setenv("DATABASE_SCHEMA", "custom")
+	t.Setenv("DATABASE_SSL_MODE", "disable")
+	t.Setenv("SSLMATE_BASE_URL", "https://sslmate.example.com")
+
+	got := Get()
+
+	for _, tc := range []struct{ name, got, want string }{
+		{"server port", got.Server.Port, "9090"},
+		{"database host", got.Database.Host, "db.internal"},
+		{"database port", got.Database.Port, "6543"},
+		{"database schema", got.Database.Schema, "custom"},
+		{"database ssl mode", got.Database.SslMode, "disable"},
+		{"sslmate base url", got.SslMate.BaseUrl, "https://sslmate.example.com"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("%s: got %q, want %q", tc.name, tc.got, tc.want)
+		}
+	}
+}
+
+func TestGetCarriesCredentialsThrough(t *testing.T) {
+	setMandatory(t)
+	t.Setenv("DATABASE_PROPS", "sslrootcert=/certs/ca.pem")
+
+	got := Get()
+
+	if got.Database.Username != "user" {
+		t.Errorf("username: got %q, want %q", got.Database.Username, "user")
+	}
+	if got.Database.Password != "password" {
+		t.Errorf("password: got %q, want %q", got.Database.Password, "password")
+	}
+	if got.Database.Props != "sslrootcert=/certs/ca.pem" {
+		t.Errorf("props: got %q, want %q", got.Database.Props, "sslrootcert=/certs/ca.pem")
+	}
+}

--- a/internal/connectorInfo/api_connector_info_service_test.go
+++ b/internal/connectorInfo/api_connector_info_service_test.go
@@ -1,0 +1,67 @@
+package connectorInfo
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/OmniTrustILM/ct-logs-discovery-provider/internal/model"
+)
+
+func testRoutes() []model.InfoResponse {
+	return []model.InfoResponse{{
+		FunctionGroupCode: model.DISCOVERY_PROVIDER,
+		Kinds:             []string{"CT-Logs"},
+		EndPoints: []model.EndpointDto{{
+			Uuid:     "b241a1a3-2f8a-4d2c-9a0b-1f0f9c2d4e5f",
+			Name:     "listSupportedFunctions",
+			Context:  "/v1",
+			Method:   http.MethodGet,
+			Required: true,
+		}},
+	}}
+}
+
+func TestListSupportedFunctionsReturnsConfiguredRoutes(t *testing.T) {
+	resp, err := NewConnectorInfoAPIService(testRoutes()).ListSupportedFunctions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Code != http.StatusOK {
+		t.Errorf("code: got %d, want %d", resp.Code, http.StatusOK)
+	}
+	body, ok := resp.Body.([]model.InfoResponse)
+	if !ok {
+		t.Fatalf("body: got %T, want []model.InfoResponse", resp.Body)
+	}
+	if len(body) != 1 {
+		t.Fatalf("got %d info responses, want 1", len(body))
+	}
+	if body[0].FunctionGroupCode != model.DISCOVERY_PROVIDER {
+		t.Errorf("function group: got %q, want %q", body[0].FunctionGroupCode, model.DISCOVERY_PROVIDER)
+	}
+}
+
+func TestListSupportedFunctionsReturnsEmptyWhenNoRoutesConfigured(t *testing.T) {
+	resp, err := NewConnectorInfoAPIService(nil).ListSupportedFunctions(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	body, ok := resp.Body.([]model.InfoResponse)
+	if !ok {
+		t.Fatalf("body: got %T, want []model.InfoResponse", resp.Body)
+	}
+	if len(body) != 0 {
+		t.Fatalf("got %d info responses, want 0", len(body))
+	}
+}
+
+func TestServiceReturnsTheRoutesItWasConstructedWith(t *testing.T) {
+	routes := testRoutes()
+	resp, _ := NewConnectorInfoAPIService(routes).ListSupportedFunctions(context.Background())
+
+	body := resp.Body.([]model.InfoResponse)
+	if body[0].EndPoints[0].Name != routes[0].EndPoints[0].Name {
+		t.Errorf("endpoint name: got %q, want %q", body[0].EndPoints[0].Name, routes[0].EndPoints[0].Name)
+	}
+}

--- a/internal/discovery/api_discovery_service.go
+++ b/internal/discovery/api_discovery_service.go
@@ -16,11 +16,24 @@ import (
 	"time"
 )
 
+// discoveryRepository is the subset of *db.DiscoveryRepository's methods that
+// DiscoveryAPIService calls. Depending on this interface instead of the
+// concrete repository type lets tests substitute a fake and exercise service
+// logic - including DiscoveryCertificates - without a live database.
+type discoveryRepository interface {
+	FindDiscoveryByUUID(uuid string) (*db.Discovery, error)
+	DeleteDiscovery(discovery *db.Discovery) error
+	CreateDiscovery(discovery *db.Discovery) error
+	List(pagination db.Pagination, discovery *db.Discovery) (*db.Pagination, error)
+	UpdateDiscovery(discovery *db.Discovery) error
+	AssociateCertificatesToDiscovery(discovery *db.Discovery, certificates ...*db.Certificate) error
+}
+
 // DiscoveryAPIService is a service that implements the logic for the DiscoveryAPIServicer
 // This service should implement the business logic for every endpoint for the DiscoveryAPI API.
 // Include any external packages or services that will be required by this service.
 type DiscoveryAPIService struct {
-	discoveryRepo *db.DiscoveryRepository
+	discoveryRepo discoveryRepository
 	log           *zap.Logger
 }
 

--- a/internal/discovery/api_discovery_service_test.go
+++ b/internal/discovery/api_discovery_service_test.go
@@ -1,6 +1,20 @@
 package discovery
 
-import "testing"
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/OmniTrustILM/ct-logs-discovery-provider/internal/db"
+	"github.com/OmniTrustILM/ct-logs-discovery-provider/internal/model"
+	"github.com/OmniTrustILM/ct-logs-discovery-provider/internal/sslmate"
+	"go.uber.org/zap"
+)
 
 // setMandatoryDatabaseEnv sets the variables config.Get treats as required, so
 // a test can read the SSLMate settings without tripping its fatal exit.
@@ -45,5 +59,163 @@ func TestNewSSLMateClientFallsBackToTheDefaultBaseURL(t *testing.T) {
 	}
 	if got != "https://api.certspotter.com" {
 		t.Errorf("server URL: got %q, want %q", got, "https://api.certspotter.com")
+	}
+}
+
+// fakeAssociateCall records one call to
+// fakeDiscoveryRepository.AssociateCertificatesToDiscovery.
+type fakeAssociateCall struct {
+	discovery    db.Discovery
+	certificates []*db.Certificate
+}
+
+// fakeDiscoveryRepository is an in-memory stand-in for *db.DiscoveryRepository
+// satisfying the discoveryRepository interface. It records the calls
+// DiscoveryCertificates makes and returns canned errors, so tests can drive
+// every branch of that method without a live database.
+type fakeDiscoveryRepository struct {
+	updateDiscoveryCalls []db.Discovery
+	updateDiscoveryErr   error
+
+	associateCalls []fakeAssociateCall
+	associateErr   error
+}
+
+func (f *fakeDiscoveryRepository) FindDiscoveryByUUID(uuid string) (*db.Discovery, error) {
+	return nil, errors.New("fakeDiscoveryRepository: FindDiscoveryByUUID not configured for this test")
+}
+
+func (f *fakeDiscoveryRepository) DeleteDiscovery(discovery *db.Discovery) error {
+	return errors.New("fakeDiscoveryRepository: DeleteDiscovery not configured for this test")
+}
+
+func (f *fakeDiscoveryRepository) CreateDiscovery(discovery *db.Discovery) error {
+	return errors.New("fakeDiscoveryRepository: CreateDiscovery not configured for this test")
+}
+
+func (f *fakeDiscoveryRepository) List(pagination db.Pagination, discovery *db.Discovery) (*db.Pagination, error) {
+	return nil, errors.New("fakeDiscoveryRepository: List not configured for this test")
+}
+
+func (f *fakeDiscoveryRepository) UpdateDiscovery(discovery *db.Discovery) error {
+	f.updateDiscoveryCalls = append(f.updateDiscoveryCalls, *discovery)
+	return f.updateDiscoveryErr
+}
+
+func (f *fakeDiscoveryRepository) AssociateCertificatesToDiscovery(discovery *db.Discovery, certificates ...*db.Certificate) error {
+	f.associateCalls = append(f.associateCalls, fakeAssociateCall{discovery: *discovery, certificates: certificates})
+	return f.associateErr
+}
+
+// newIssuancesServer starts an httptest server playing the role of the
+// SSLMate CT search API used by DiscoveryCertificates. It answers the first
+// request with issuances and every request after that with an empty page, so
+// the discovery loop stops paginating. It always succeeds on the first
+// attempt so the retry loop in DiscoveryCertificates - a 15 second base delay
+// - never engages; a test relying on that retry path would hang for minutes.
+func newIssuancesServer(t *testing.T, issuances []sslmate.IssuanceObject) *httptest.Server {
+	t.Helper()
+
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		page := issuances
+		if calls.Add(1) > 1 {
+			page = []sslmate.IssuanceObject{}
+		}
+		if err := json.NewEncoder(w).Encode(page); err != nil {
+			t.Errorf("encode issuances response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func TestDiscoveryCertificatesCompletesWhenNoIssuancesAreFound(t *testing.T) {
+	setMandatoryDatabaseEnv(t)
+	server := newIssuancesServer(t, nil)
+	t.Setenv("SSLMATE_BASE_URL", server.URL)
+
+	repo := &fakeDiscoveryRepository{}
+	svc := &DiscoveryAPIService{discoveryRepo: repo, log: zap.NewNop()}
+	target := &db.Discovery{UUID: "discovery-uuid", Name: "example.com"}
+
+	svc.DiscoveryCertificates(context.Background(), target, "example.com", "", false, false, time.Now().Add(-time.Hour), time.Now())
+
+	if target.Status != model.COMPLETED {
+		t.Fatalf("status: got %q, want %q", target.Status, model.COMPLETED)
+	}
+	if len(repo.associateCalls) != 0 {
+		t.Errorf("AssociateCertificatesToDiscovery calls: got %d, want 0", len(repo.associateCalls))
+	}
+	if len(repo.updateDiscoveryCalls) != 1 {
+		t.Fatalf("UpdateDiscovery calls: got %d, want 1", len(repo.updateDiscoveryCalls))
+	}
+	if got := repo.updateDiscoveryCalls[0].Status; got != model.COMPLETED {
+		t.Errorf("updated status: got %q, want %q", got, model.COMPLETED)
+	}
+}
+
+func TestDiscoveryCertificatesAssociatesDiscoveredCertificates(t *testing.T) {
+	setMandatoryDatabaseEnv(t)
+	issuance := sslmate.IssuanceObject{
+		Id:      "issuance-1",
+		CertDer: "certificate-der-bytes",
+		Issuer:  sslmate.IssuerObject{FriendlyName: "Example CA"},
+	}
+	server := newIssuancesServer(t, []sslmate.IssuanceObject{issuance})
+	t.Setenv("SSLMATE_BASE_URL", server.URL)
+
+	repo := &fakeDiscoveryRepository{}
+	svc := &DiscoveryAPIService{discoveryRepo: repo, log: zap.NewNop()}
+	target := &db.Discovery{UUID: "discovery-uuid", Name: "example.com"}
+
+	svc.DiscoveryCertificates(context.Background(), target, "example.com", "", false, false, time.Now().Add(-time.Hour), time.Now())
+
+	if target.Status != model.COMPLETED {
+		t.Fatalf("status: got %q, want %q", target.Status, model.COMPLETED)
+	}
+	if len(repo.associateCalls) != 1 {
+		t.Fatalf("AssociateCertificatesToDiscovery calls: got %d, want 1", len(repo.associateCalls))
+	}
+	certs := repo.associateCalls[0].certificates
+	if len(certs) != 1 {
+		t.Fatalf("certificates in call: got %d, want 1", len(certs))
+	}
+	if certs[0].Base64Content != issuance.CertDer {
+		t.Errorf("certificate content: got %q, want %q", certs[0].Base64Content, issuance.CertDer)
+	}
+	if certs[0].UUID == "" {
+		t.Error("certificate UUID: got empty string, want a deterministic UUID")
+	}
+}
+
+func TestDiscoveryCertificatesFailsWhenAssociationErrors(t *testing.T) {
+	setMandatoryDatabaseEnv(t)
+	issuance := sslmate.IssuanceObject{
+		Id:      "issuance-1",
+		CertDer: "certificate-der-bytes",
+		Issuer:  sslmate.IssuerObject{FriendlyName: "Example CA"},
+	}
+	server := newIssuancesServer(t, []sslmate.IssuanceObject{issuance})
+	t.Setenv("SSLMATE_BASE_URL", server.URL)
+
+	repo := &fakeDiscoveryRepository{associateErr: errors.New("association failed")}
+	svc := &DiscoveryAPIService{discoveryRepo: repo, log: zap.NewNop()}
+	target := &db.Discovery{UUID: "discovery-uuid", Name: "example.com"}
+
+	svc.DiscoveryCertificates(context.Background(), target, "example.com", "", false, false, time.Now().Add(-time.Hour), time.Now())
+
+	if target.Status != model.FAILED {
+		t.Fatalf("status: got %q, want %q", target.Status, model.FAILED)
+	}
+	if len(target.Meta) == 0 {
+		t.Error("expected failure metadata to be recorded on the discovery")
+	}
+	if len(repo.updateDiscoveryCalls) != 1 {
+		t.Fatalf("UpdateDiscovery calls: got %d, want 1", len(repo.updateDiscoveryCalls))
+	}
+	if got := repo.updateDiscoveryCalls[0].Status; got != model.FAILED {
+		t.Errorf("updated status: got %q, want %q", got, model.FAILED)
 	}
 }

--- a/internal/health/api_health_check_service_test.go
+++ b/internal/health/api_health_check_service_test.go
@@ -1,0 +1,62 @@
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/OmniTrustILM/ct-logs-discovery-provider/internal/model"
+)
+
+func TestCheckHealthReportsOK(t *testing.T) {
+	resp, err := NewHealthCheckAPIService().CheckHealth(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Code != http.StatusOK {
+		t.Errorf("code: got %d, want %d", resp.Code, http.StatusOK)
+	}
+	body, ok := resp.Body.(model.HealthDto)
+	if !ok {
+		t.Fatalf("body: got %T, want model.HealthDto", resp.Body)
+	}
+	if body.Status != model.OK {
+		t.Errorf("status: got %q, want %q", body.Status, model.OK)
+	}
+}
+
+func TestRoutesExposeHealthEndpoint(t *testing.T) {
+	routes := NewHealthCheckAPIController(NewHealthCheckAPIService()).Routes()
+
+	route, ok := routes["CheckHealth"]
+	if !ok {
+		t.Fatal(`no route registered under "CheckHealth"`)
+	}
+	if route.Method != http.MethodGet {
+		t.Errorf("method: got %q, want %q", route.Method, http.MethodGet)
+	}
+	if route.Pattern != "/v1/health" {
+		t.Errorf("pattern: got %q, want %q", route.Pattern, "/v1/health")
+	}
+}
+
+func TestCheckHealthHandlerWritesOKJSON(t *testing.T) {
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+
+	controller := NewHealthCheckAPIController(NewHealthCheckAPIService())
+	controller.Routes()["CheckHealth"].HandlerFunc(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want %d", rec.Code, http.StatusOK)
+	}
+	var body model.HealthDto
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Status != model.OK {
+		t.Errorf("status: got %q, want %q", body.Status, model.OK)
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -2,12 +2,8 @@ package utils
 
 import (
 	"crypto/md5"
-	"crypto/x509"
 	"encoding/hex"
-	"encoding/pem"
-	"fmt"
 	"github.com/OmniTrustILM/ct-logs-discovery-provider/internal/logger"
-	"strings"
 
 	"github.com/google/uuid"
 )
@@ -43,59 +39,4 @@ func DeterministicGUID(parts ...string) string {
 	}
 
 	return uuidByte.String()
-}
-
-func ExtractCommonName(csr []byte) (string, error) {
-
-	csrParsed, err := x509.ParseCertificateRequest(csr)
-	if err != nil {
-		log.Error("Failed to parse CSR: " + err.Error())
-		return "", fmt.Errorf("failed to parse CSR: %v", err)
-	}
-
-	commonName := csrParsed.Subject.CommonName
-	return commonName, nil
-}
-
-func ExtractSerialNumber(certificate []byte) (string, error) {
-	certificateParsed, errParse := x509.ParseCertificate(certificate)
-	if errParse != nil {
-		log.Error("Failed to parse certificate: " + errParse.Error())
-	}
-	bytes := certificateParsed.SerialNumber.Bytes()
-
-	hexStr := make([]string, len(bytes))
-	for i, b := range bytes {
-		hexStr[i] = fmt.Sprintf("%02X", b)
-	}
-	return strings.ToLower(strings.Join(hexStr, ":")), nil
-}
-
-func GetCertificatesFromDer(pemData []byte) ([]string, error) {
-
-	var certs []string
-	for {
-		block, rest := pem.Decode(pemData)
-		if block == nil {
-			break
-		}
-
-		if block.Type != "CERTIFICATE" {
-			return nil, fmt.Errorf("failed to decode PEM block containing certificate")
-		}
-
-		cert, err := x509.ParseCertificate(block.Bytes)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse certificate: %v", err)
-		}
-		certBlock := pem.EncodeToMemory(&pem.Block{
-			Type:  "CERTIFICATE",
-			Bytes: cert.Raw,
-		})
-
-		certs = append(certs, string(certBlock))
-		pemData = rest
-	}
-
-	return certs, nil
 }


### PR DESCRIPTION
Establishes unit test coverage for the hand-written packages and removes utility functions that have no callers.

## Changes

- The discovery service now depends on an interface for the repository methods it uses, so its behaviour can be exercised without a database. The constructor is unchanged and existing callers are unaffected
- Added tests for certificate discovery, covering the successful, empty and association-failure paths against a local HTTP server
- Added tests for the configuration loader, the health service and the connector info service
- Removed `ExtractCommonName`, `ExtractSerialNumber` and `GetCertificatesFromDer` from the utility package, none of which had any caller, along with the imports only they used
